### PR TITLE
Fix asynchronous injection of html and button click index in ActionSh…

### DIFF
--- a/src/windows/ActionSheetProxy.js
+++ b/src/windows/ActionSheetProxy.js
@@ -12,6 +12,10 @@ ActionSheet.prototype.show = function (options, successCallback, errorCallback) 
     ActionSheet.prototype.successCallBack = successCallback;
     ActionSheet.prototype.errorCallback = errorCallback;
 
+    if (cordova.platformId == "windows") {
+        ActionSheet.prototype._injectWinJsFlyoutHTML();
+    }
+
     if (options) {
         var actionSheetProxyFlyoutDiv = document.getElementById("actionSheetProxyFlyoutDiv");
         //Settings popup
@@ -41,7 +45,7 @@ ActionSheet.prototype.show = function (options, successCallback, errorCallback) 
                 //var bodys = document.getElementsByClassName('bodyClass')[0];
                 var anchor = document.getElementById("actionSheetSetPoint");
                 if (anchor) {
-                    fly.winControl.show(anchor, "top");
+                    fly.winControl.show(anchor, "bottom");
                 }
 
 
@@ -81,10 +85,6 @@ ActionSheet.prototype.ANDROID_THEMES = {
 ActionSheet.prototype.install = function () {
     if (!window.plugins) {
         window.plugins = {};
-    }
-    if (cordova.platformId == "windows") {
-        //this._injectWinJsFlyoutHTML();
-        ActionSheet.prototype._injectWinJsFlyoutHTML();
     }
     window.plugins.actionsheet = new ActionSheet();
 
@@ -126,13 +126,14 @@ ActionSheet.prototype._addbuttons = function (lables, destinationCtrl) {
     if (lables && destinationCtrl) {
         for (var i = 0; i < lables.length; i++) {
             var btn = this._generateButton(lables[i], this._getButtonStyle());
-            btn.onclick = function () {
-                if (ActionSheet.prototype.successCallBack) {
-                    ActionSheet.prototype.successCallBack(btn.tabIndex);
-                    ActionSheet.prototype.hide();
-                }
-                
-            }
+	    (function (i) {
+            	btn.onclick = function () {
+                    if (ActionSheet.prototype.successCallBack) {
+                    	ActionSheet.prototype.successCallBack(i + 1);
+                    	ActionSheet.prototype.hide();
+                    }                
+            	}
+            })(i);
             destinationCtrl.appendChild(btn);
         }
     }


### PR DESCRIPTION
…eetProxy.js

html required body to be there. But if at the time of install of this plugin (which is at the start of loading of html page), body element has not still loaded, then injection of html would fail as was happening in my case. This html should be injected only when show method is called as it is not needed prior to that. Also, in case of loading templates through underscore.js, the template html can replace this injected code if it is injected so early. 

btn.onclick event was not binding to the correct button index due to closure issue. So, created a wrapper of an immediate function over the onclick handler.