### PR TITLE
Added support for Cordova Android 7 (patch)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
 
   <!-- android -->
   <platform name="android">
-    <config-file target="res/xml/config.xml" parent="/*">
+    <config-file target="app/src/main/res/xml/config.xml" parent="/*">
       <feature name="ActionSheet">
         <param name="android-package" value="nl.xservices.plugins.actionsheet.ActionSheet"/>
       </feature>


### PR DESCRIPTION
Cordova Android 7.0.0 changed the file structure which breaks this plugin. This PR fixes that.

https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html